### PR TITLE
print function instead of statement

### DIFF
--- a/0.8.0/_sources/gettingstarted.rst.txt
+++ b/0.8.0/_sources/gettingstarted.rst.txt
@@ -133,7 +133,7 @@ For OLS, this is achieved by:
 
     mod = sm.OLS(y, X)    # Describe model
     res = mod.fit()       # Fit model
-    print res.summary()   # Summarize model
+    print(res.summary())   # Summarize model
 
 
 The ``res`` object has many useful attributes. For example, we can extract


### PR DESCRIPTION
The current stable docs show an error:

```
  File "<ipython-input-15-6ef19fe76b73>", line 1
    print res.summary()   # Summarize model
            ^
SyntaxError: invalid syntax
```